### PR TITLE
Add library bundling/loading capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 out/
 .gradle/
 
-bin/
+bin/trinity.jar
 build/
 test-ty/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Trinity is a dynamically-typed, object-oriented programming language.
 It is heavily influenced by aspects of [Java](https://www.java.com/) and [Ruby](https://www.ruby-lang.org/).
 
 ### Repository Structure
+- `bin` - Batch/Shell scripts
 - `lib` - Trinity standard library
 - `logo` - PNG/SVG logos for Trinity
 - `src` - Java source code for the Trinity interpreter

--- a/bin/trinity
+++ b/bin/trinity
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+FILE="$DIR/trinity.jar"
+if [ ! -f $FILE ]; then
+    echo "ERROR: Trinity interpreter not found."
+else
+    java -jar $FILE "$@"
+fi

--- a/bin/trinity.bat
+++ b/bin/trinity.bat
@@ -1,0 +1,6 @@
+@echo off
+if NOT exist "%~dp0trinity.jar" (
+    echo ERROR: Trinity interpreter not found.
+) else (
+    java -jar "%~dp0trinity.jar" %*
+)

--- a/bin/tybundle
+++ b/bin/tybundle
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+FILE="$DIR/trinity.jar"
+if [ ! -f $FILE ]; then
+    echo "ERROR: Trinity interpreter not found."
+else
+    java -cp $FILE com.github.chrisblutz.trinity.libraries.compiling.LibraryCompiler
+fi

--- a/bin/tybundle.bat
+++ b/bin/tybundle.bat
@@ -1,0 +1,6 @@
+@echo off
+if NOT exist "%~dp0trinity.jar" (
+    echo ERROR: Trinity interpreter not found.
+) else (
+    java -cp "%~dp0trinity.jar" com.github.chrisblutz.trinity.libraries.compiling.LibraryCompiler
+)

--- a/src/main/java/com/github/chrisblutz/trinity/Trinity.java
+++ b/src/main/java/com/github/chrisblutz/trinity/Trinity.java
@@ -2,6 +2,7 @@ package com.github.chrisblutz.trinity;
 
 import com.github.chrisblutz.trinity.bootstrap.Bootstrap;
 import com.github.chrisblutz.trinity.cli.CLI;
+import com.github.chrisblutz.trinity.libraries.Libraries;
 
 
 /**
@@ -26,6 +27,8 @@ public class Trinity {
     public static void main(String[] args) {
         
         Bootstrap.bootstrap();
+        
+        Libraries.loadAll();
         
         CLI.start(args);
     }

--- a/src/main/java/com/github/chrisblutz/trinity/bootstrap/Bootstrap.java
+++ b/src/main/java/com/github/chrisblutz/trinity/bootstrap/Bootstrap.java
@@ -30,10 +30,4 @@ public class Bootstrap {
         // Load system properties
         ClassRegistry.getClass("System").tyInvoke("loadProperties", new TYRuntime(), null, null, TYObject.NIL);
     }
-    
-    public static void bootstrapUI() {
-        
-        // Load UI library
-        TrinityParser.parse(new File("lib-ui/"));
-    }
 }

--- a/src/main/java/com/github/chrisblutz/trinity/cli/CLI.java
+++ b/src/main/java/com/github/chrisblutz/trinity/cli/CLI.java
@@ -1,7 +1,7 @@
 package com.github.chrisblutz.trinity.cli;
 
-import com.github.chrisblutz.trinity.bootstrap.Bootstrap;
 import com.github.chrisblutz.trinity.info.TrinityInfo;
+import com.github.chrisblutz.trinity.libraries.Libraries;
 import com.github.chrisblutz.trinity.runner.Runner;
 
 import java.io.File;
@@ -121,13 +121,7 @@ public class CLI {
         
         for (String lib : params) {
             
-            switch (lib) {
-                
-                case "Trinity.UI":
-                    
-                    Bootstrap.bootstrapUI();
-                    break;
-            }
+            Libraries.load(lib);
         }
     }
     

--- a/src/main/java/com/github/chrisblutz/trinity/libraries/Libraries.java
+++ b/src/main/java/com/github/chrisblutz/trinity/libraries/Libraries.java
@@ -1,0 +1,242 @@
+package com.github.chrisblutz.trinity.libraries;
+
+import com.github.chrisblutz.trinity.cli.CLI;
+import com.github.chrisblutz.trinity.parser.TrinityParser;
+import com.github.chrisblutz.trinity.utils.FileUtils;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+
+/**
+ * @author Christopher Lutz
+ */
+public class Libraries {
+    
+    public static final String LIBRARY_DIRECTORY = "ext-libs";
+    public static final String LIBRARY_EXTENSION = ".tyb";
+    public static final String INTERNAL_NATIVE_DIRECTORY = "ext/";
+    public static final String INTERNAL_SOURCE_DIRECTORY = "lib/";
+    
+    public static final String CLASS_EXTENSION = ".class";
+    
+    private static Map<String, File> libraryFiles = new HashMap<>();
+    
+    private static List<NativeLibrary> libraries = new ArrayList<>();
+    
+    public static void loadAll() {
+        
+        File dir = new File(LIBRARY_DIRECTORY);
+        
+        if (dir.exists() && dir.isDirectory()) {
+            
+            File[] files = dir.listFiles(getExtensionFilter());
+            
+            if (files != null) {
+                
+                for (File f : files) {
+                    
+                    load(f);
+                }
+            }
+        }
+    }
+    
+    public static void load(String name) {
+        
+        if (libraryFiles.containsKey(name.toLowerCase())) {
+            
+            File file = libraryFiles.get(name.toLowerCase());
+            
+            performLoad(name, file);
+            
+        } else {
+            
+            System.err.println("Library '" + name + "' not found.");
+        }
+    }
+    
+    private static void load(File file) {
+        
+        String name = file.getName();
+        name = name.substring(0, name.length() - LIBRARY_EXTENSION.length());
+        libraryFiles.put(name.toLowerCase(), file);
+    }
+    
+    private static FilenameFilter getExtensionFilter() {
+        
+        return (dir, name) -> name.endsWith(LIBRARY_EXTENSION);
+    }
+    
+    private static void performLoad(String name, File file) {
+        
+        try {
+            
+            ZipFile zip = new ZipFile(file);
+            Enumeration<? extends ZipEntry> entries = zip.entries();
+            
+            List<ZipEntry> natives = new ArrayList<>();
+            List<ZipEntry> sources = new ArrayList<>();
+            
+            while (entries.hasMoreElements()) {
+                
+                ZipEntry entry = entries.nextElement();
+                
+                if (!entry.isDirectory() && entry.getName().startsWith(INTERNAL_NATIVE_DIRECTORY)) {
+                    
+                    natives.add(entry);
+                    
+                } else if (!entry.isDirectory() && entry.getName().startsWith(INTERNAL_SOURCE_DIRECTORY)) {
+                    
+                    sources.add(entry);
+                }
+            }
+            
+            loadNatives(name, zip, natives);
+            
+            for (NativeLibrary lib : libraries) {
+                
+                lib.initialize();
+            }
+            
+            loadSources(name, zip, file, sources);
+            
+        } catch (IOException e) {
+            
+            System.err.println("An IO error occurred while loading library '" + name + '.');
+            
+            if (CLI.isDebuggingEnabled()) {
+                
+                e.printStackTrace();
+            }
+        }
+    }
+    
+    private static void loadNatives(String libName, ZipFile file, List<ZipEntry> natives) throws IOException {
+        
+        List<String> names = new ArrayList<>();
+        
+        for (ZipEntry entry : natives) {
+            
+            if (entry.getName().endsWith(CLASS_EXTENSION)) {
+                
+                String name = entry.getName();
+                name = name.substring(INTERNAL_NATIVE_DIRECTORY.length(), name.length() - CLASS_EXTENSION.length());
+                name = name.replace(File.separatorChar, '/').replace('/', '.');
+                
+                names.add(name);
+                
+                InputStream is = null;
+                
+                try {
+                    
+                    is = file.getInputStream(entry);
+                    File output = new File("temp-" + entry.getName());
+                    if (output.getParentFile() != null) {
+                        
+                        output.getParentFile().mkdirs();
+                    }
+                    Path path = output.toPath();
+                    
+                    Files.copy(is, path, StandardCopyOption.REPLACE_EXISTING);
+                    
+                } catch (IOException e) {
+                    
+                    e.printStackTrace();
+                }
+                
+                if (is != null) {
+                    
+                    is.close();
+                }
+            }
+        }
+        
+        File extFiles = new File("temp-ext/");
+        URL url = extFiles.toURI().toURL();
+        URLClassLoader loader = URLClassLoader.newInstance(new URL[]{url});
+        
+        List<Class<?>> classes = new ArrayList<>();
+        
+        for (String name : names) {
+            
+            try {
+                
+                classes.add(loader.loadClass(name));
+                
+            } catch (ClassNotFoundException e) {
+                
+                System.err.println("Could not find class '" + name + "' inside library '" + libName + "'.");
+            }
+        }
+        
+        loader.close();
+        
+        // Remove temp directory
+        FileUtils.delete(extFiles);
+        
+        for (Class<?> c : classes) {
+            
+            if (c.getSuperclass() == NativeLibrary.class) {
+                
+                try {
+                    
+                    NativeLibrary lib = (NativeLibrary) c.getConstructor().newInstance();
+                    libraries.add(lib);
+                    
+                } catch (NoSuchMethodException e) {
+                    
+                    System.err.println("Class '" + c.getName() + "' inside library '" + libName + "' does not have a no-argument constructor.");
+                    
+                } catch (Exception e) {
+                    
+                    System.err.println("An error occurred while loading class '" + c.getName() + "' inside library '" + libName + "'.");
+                    
+                    if (CLI.isDebuggingEnabled()) {
+                        
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+    }
+    
+    private static void loadSources(String libName, ZipFile zip, File file, List<ZipEntry> sources) {
+        
+        for (ZipEntry entry : sources) {
+            
+            if (entry.getName().endsWith(TrinityParser.SOURCE_EXTENSION)) {
+                
+                String filename = entry.getName();
+                filename = filename.replace(File.separatorChar, '/');
+                filename = filename.substring(filename.lastIndexOf('/') + 1);
+                
+                try {
+                    
+                    InputStream is = zip.getInputStream(entry);
+                    TrinityParser.parse(is, filename, file);
+                    is.close();
+                    
+                } catch (Exception e) {
+                    
+                    System.err.println("An error occurred while loading '" + filename + "' from library '" + libName + "'.");
+                    
+                    if (CLI.isDebuggingEnabled()) {
+                        
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/chrisblutz/trinity/libraries/NativeLibrary.java
+++ b/src/main/java/com/github/chrisblutz/trinity/libraries/NativeLibrary.java
@@ -1,0 +1,9 @@
+package com.github.chrisblutz.trinity.libraries;
+
+/**
+ * @author Christopher Lutz
+ */
+public abstract class NativeLibrary {
+    
+    public abstract void initialize();
+}

--- a/src/main/java/com/github/chrisblutz/trinity/libraries/compiling/CompileException.java
+++ b/src/main/java/com/github/chrisblutz/trinity/libraries/compiling/CompileException.java
@@ -1,0 +1,13 @@
+package com.github.chrisblutz.trinity.libraries.compiling;
+
+/**
+ * @author Christopher Lutz
+ */
+public class CompileException extends RuntimeException {
+    
+    public CompileException(String file, long line, String message) {
+        
+        super("Compilation error on line " + line + " in " + file + ".");
+        setStackTrace(new StackTraceElement[]{});
+    }
+}

--- a/src/main/java/com/github/chrisblutz/trinity/libraries/compiling/LibraryCompiler.java
+++ b/src/main/java/com/github/chrisblutz/trinity/libraries/compiling/LibraryCompiler.java
@@ -29,6 +29,7 @@ public class LibraryCompiler {
     public static final String OUTPUT_DIRECTORY = "out/";
     
     public static final String NATIVE_SOURCES_PROPERTY = "nativeSource";
+    public static final String NATIVE_RESOURCES_PROPERTY = "nativeResource";
     public static final String TRINITY_SOURCES_PROPERTY = "source";
     public static final String LIBRARY_NAME_PROPERTY = "name";
     public static final String LIBRARY_VERSION_PROPERTY = "version";
@@ -77,6 +78,7 @@ public class LibraryCompiler {
         String libName = properties.getProperty(LIBRARY_NAME_PROPERTY);
         String version = properties.getProperty(LIBRARY_VERSION_PROPERTY);
         String nativeSource = properties.getProperty(NATIVE_SOURCES_PROPERTY);
+        String nativeResource = properties.getProperty(NATIVE_RESOURCES_PROPERTY);
         String source = properties.getProperty(TRINITY_SOURCES_PROPERTY);
         
         if (libName == null) {
@@ -129,6 +131,19 @@ public class LibraryCompiler {
             
             File tempDir = new File(TEMPORARY_COMPILE_DIRECTORY);
             collectOnlyFiles(nativeFiles, nativeNames, tempDir, tempDir.getAbsolutePath());
+        }
+        
+        if (nativeResource != null) {
+            
+            File nativeResourceDir = new File(nativeResource);
+            
+            if (!nativeResourceDir.exists()) {
+                
+                System.err.println("Native resource directory " + nativeSource + " does not exist.");
+                return;
+            }
+            
+            collectOnlyFiles(nativeFiles, nativeNames, nativeResourceDir, nativeResourceDir.getAbsolutePath());
         }
         
         if (source != null) {

--- a/src/main/java/com/github/chrisblutz/trinity/libraries/compiling/LibraryCompiler.java
+++ b/src/main/java/com/github/chrisblutz/trinity/libraries/compiling/LibraryCompiler.java
@@ -1,0 +1,343 @@
+package com.github.chrisblutz.trinity.libraries.compiling;
+
+import com.github.chrisblutz.trinity.cli.CLI;
+import com.github.chrisblutz.trinity.libraries.Libraries;
+import com.github.chrisblutz.trinity.utils.FileUtils;
+
+import javax.tools.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+
+/**
+ * @author Christopher Lutz
+ */
+public class LibraryCompiler {
+    
+    public static final String TYBUNDLE_FILE = ".tybundle";
+    
+    public static final String TEMPORARY_COMPILE_DIRECTORY = "temp-out/";
+    public static final String OUTPUT_DIRECTORY = "out/";
+    
+    public static final String NATIVE_SOURCES_PROPERTY = "nativeSource";
+    public static final String TRINITY_SOURCES_PROPERTY = "source";
+    public static final String LIBRARY_NAME_PROPERTY = "name";
+    public static final String LIBRARY_VERSION_PROPERTY = "version";
+    
+    public static final String JAVA_SOURCE_EXTENSION = ".java";
+    
+    public static void compile() {
+        
+        if (!checkSystemEnvironment()) {
+            
+            System.err.println("Environment variable TRINITY_HOME not found.  It should contain the home directory of your Trinity installation.");
+            return;
+        }
+        
+        File bundleFile = new File(TYBUNDLE_FILE);
+        
+        if (!bundleFile.exists()) {
+            
+            System.err.println("No " + TYBUNDLE_FILE + " file found in the current location.");
+            return;
+        }
+        
+        Properties properties = new Properties();
+        
+        try {
+            
+            FileInputStream inputStream = new FileInputStream(bundleFile);
+            properties.load(inputStream);
+            inputStream.close();
+            
+        } catch (Exception e) {
+            
+            System.err.println("An error occurred while reading the " + TYBUNDLE_FILE + " file.");
+            
+            if (CLI.isDebuggingEnabled()) {
+                
+                e.printStackTrace();
+            }
+        }
+        
+        String libName = properties.getProperty(LIBRARY_NAME_PROPERTY);
+        String version = properties.getProperty(LIBRARY_VERSION_PROPERTY);
+        String nativeSource = properties.getProperty(NATIVE_SOURCES_PROPERTY);
+        String source = properties.getProperty(TRINITY_SOURCES_PROPERTY);
+        
+        if (libName == null) {
+            
+            System.err.println(TYBUNDLE_FILE + " must declare a " + LIBRARY_NAME_PROPERTY + " property.");
+            return;
+            
+        } else if (version == null) {
+            
+            System.err.println(TYBUNDLE_FILE + " must declare a " + LIBRARY_VERSION_PROPERTY + " property.");
+            return;
+        }
+        
+        List<File> nativeFiles = new ArrayList<>();
+        List<String> nativeNames = new ArrayList<>();
+        List<File> sourceFiles = new ArrayList<>();
+        List<String> sourceNames = new ArrayList<>();
+        
+        if (nativeSource != null) {
+            
+            File nativeSourceDir = new File(nativeSource);
+            
+            if (!nativeSourceDir.exists()) {
+                
+                System.err.println("Native source directory " + nativeSource + " does not exist.");
+                return;
+            }
+            
+            JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+            
+            if (compiler == null) {
+                
+                System.err.println("No Java compiler found.  Make sure a JDK is installed.");
+                return;
+            }
+            
+            try {
+                
+                compileNativeSources(compiler, nativeSourceDir);
+                
+            } catch (IOException e) {
+                
+                System.err.println("An IO exception occurred while bundling this library.");
+                
+                if (CLI.isDebuggingEnabled()) {
+                    
+                    e.printStackTrace();
+                }
+            }
+            
+            File tempDir = new File(TEMPORARY_COMPILE_DIRECTORY);
+            collectOnlyFiles(nativeFiles, nativeNames, tempDir, tempDir.getAbsolutePath());
+        }
+        
+        if (source != null) {
+            
+            File sourceDir = new File(source);
+            
+            if (!sourceDir.exists()) {
+                
+                System.err.println("Source directory " + source + " does not exist.");
+                return;
+            }
+            
+            collectOnlyFiles(sourceFiles, sourceNames, sourceDir, sourceDir.getAbsolutePath());
+        }
+        
+        try {
+            
+            File output = new File(OUTPUT_DIRECTORY);
+            output.mkdirs();
+            
+            File tybFile = new File(output, libName + "-" + version + Libraries.LIBRARY_EXTENSION);
+            writeBundle(tybFile, nativeFiles, nativeNames, sourceFiles, sourceNames);
+            
+            System.out.println("Generated '" + tybFile.getName() + "' successfully.");
+            
+        } catch (IOException e) {
+            
+            System.err.println("An IO error occurred while writing the library to a bundle.");
+            
+            if (CLI.isDebuggingEnabled()) {
+                
+                e.printStackTrace();
+            }
+        }
+        
+        // Remove temporary compilation directory
+        FileUtils.delete(new File(TEMPORARY_COMPILE_DIRECTORY));
+    }
+    
+    private static void compileNativeSources(JavaCompiler compiler, File source) throws IOException {
+        
+        File tempDir = new File(TEMPORARY_COMPILE_DIRECTORY);
+        copySources(source, tempDir, source.getAbsolutePath());
+        
+        List<File> sourceFiles = new ArrayList<>();
+        File[] files = tempDir.listFiles();
+        if (files != null) {
+            
+            for (File f : files) {
+                
+                generateListOfSources(sourceFiles, f);
+            }
+            
+            if (sourceFiles.size() > 0) {
+                
+                List<String> args = new ArrayList<>();
+                args.add("-g");
+                
+                DiagnosticCollector<JavaFileObject> diagnosticCollector = new DiagnosticCollector<>();
+                StandardJavaFileManager manager = compiler.getStandardFileManager(diagnosticCollector, null, null);
+                Iterable<? extends JavaFileObject> compilationUnits = manager.getJavaFileObjects(sourceFiles.toArray(new File[sourceFiles.size()]));
+                
+                JavaCompiler.CompilationTask task = compiler.getTask(null, manager, diagnosticCollector, args, null, compilationUnits);
+                
+                boolean result = task.call();
+                
+                if (!result) {
+                    
+                    System.err.println("Compilation errors occurred during building.");
+                    
+                    for (Diagnostic<? extends JavaFileObject> d : diagnosticCollector.getDiagnostics()) {
+                        
+                        CompileException exception = new CompileException(d.getSource().getName(), d.getLineNumber(), d.getMessage(null));
+                        exception.printStackTrace();
+                    }
+                }
+                
+                // Remove temporary source files (we don't want to bundle the .java files)
+                for (File f : sourceFiles) {
+                    
+                    f.delete();
+                }
+            }
+        }
+    }
+    
+    private static void copySources(File current, File target, String sourcePath) throws IOException {
+        
+        if (current.isDirectory()) {
+            
+            String targetDir = getFileNameWithoutPath(current.getAbsolutePath(), sourcePath);
+            new File(target, targetDir).mkdirs();
+            
+            File[] files = current.listFiles();
+            
+            if (files != null) {
+                
+                for (File f : files) {
+                    
+                    if (f.isDirectory()) {
+                        
+                        copySources(f, target, sourcePath);
+                        
+                    } else {
+                        
+                        String targetFile = getFileNameWithoutPath(f.getAbsolutePath(), sourcePath);
+                        Files.copy(f.toPath(), new File(target, targetFile).toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    }
+                }
+            }
+        }
+    }
+    
+    private static void generateListOfSources(List<File> sourceFiles, File current) {
+        
+        if (current.isDirectory()) {
+            
+            File[] files = current.listFiles();
+            
+            if (files != null) {
+                
+                for (File f : files) {
+                    
+                    generateListOfSources(sourceFiles, f);
+                }
+            }
+            
+        } else if (current.getName().endsWith(JAVA_SOURCE_EXTENSION)) {
+            
+            sourceFiles.add(current);
+        }
+    }
+    
+    private static void collectOnlyFiles(List<File> files, List<String> names, File current, String origPath) {
+        
+        if (current.isDirectory()) {
+            
+            File[] fileArr = current.listFiles();
+            
+            if (fileArr != null) {
+                
+                for (File f : fileArr) {
+                    
+                    collectOnlyFiles(files, names, f, origPath);
+                }
+            }
+            
+        } else {
+            
+            files.add(current);
+            String name = getFileNameWithoutPath(current.getAbsolutePath(), origPath);
+            names.add(name);
+        }
+    }
+    
+    private static String getFileNameWithoutPath(String fullPath, String cutPath) {
+        
+        if (!cutPath.replace(File.separatorChar, '/').endsWith("/")) {
+            
+            cutPath = cutPath + "/";
+        }
+        
+        if (cutPath.length() <= fullPath.length()) {
+            
+            return fullPath.substring(cutPath.length());
+            
+        } else {
+            
+            return "";
+        }
+    }
+    
+    private static void writeBundle(File bundle, List<File> nativeFiles, List<String> nativeNames, List<File> sourceFiles, List<String> sourceNames) throws IOException {
+        
+        if (bundle.exists()) {
+            
+            bundle.delete();
+        }
+        
+        ZipOutputStream out = new ZipOutputStream(new FileOutputStream(bundle));
+        
+        if (nativeFiles.size() > 0) {
+            
+            for (int i = 0; i < nativeFiles.size() && i < nativeNames.size(); i++) {
+                
+                File file = nativeFiles.get(i);
+                String name = nativeNames.get(i);
+                
+                ZipEntry entry = new ZipEntry(Libraries.INTERNAL_NATIVE_DIRECTORY + name);
+                out.putNextEntry(entry);
+                
+                Files.copy(file.toPath(), out);
+            }
+        }
+        
+        if (sourceFiles.size() > 0) {
+            
+            for (int i = 0; i < sourceFiles.size() && i < sourceNames.size(); i++) {
+                
+                File file = sourceFiles.get(i);
+                String name = sourceNames.get(i);
+                
+                ZipEntry entry = new ZipEntry(Libraries.INTERNAL_SOURCE_DIRECTORY + name);
+                out.putNextEntry(entry);
+                
+                Files.copy(file.toPath(), out);
+            }
+        }
+        
+        out.close();
+    }
+    
+    private static boolean checkSystemEnvironment() {
+        
+        return System.getenv().containsKey("TRINITY_HOME");
+    }
+}

--- a/src/main/java/com/github/chrisblutz/trinity/libraries/compiling/LibraryCompiler.java
+++ b/src/main/java/com/github/chrisblutz/trinity/libraries/compiling/LibraryCompiler.java
@@ -35,6 +35,11 @@ public class LibraryCompiler {
     
     public static final String JAVA_SOURCE_EXTENSION = ".java";
     
+    public static void main(String[] args) {
+        
+        compile();
+    }
+    
     public static void compile() {
         
         if (!checkSystemEnvironment()) {

--- a/src/main/java/com/github/chrisblutz/trinity/utils/FileUtils.java
+++ b/src/main/java/com/github/chrisblutz/trinity/utils/FileUtils.java
@@ -17,4 +17,22 @@ public class FileUtils {
         
         return "";
     }
+    
+    public static void delete(File file) {
+        
+        if (file.isDirectory()) {
+            
+            File[] files = file.listFiles();
+            
+            if (files != null) {
+                
+                for (File f : files) {
+                    
+                    delete(f);
+                }
+            }
+        }
+        
+        file.delete();
+    }
 }


### PR DESCRIPTION
Adds a library loader and a library compiler.  Libraries are essentially ZIP files with the `.tyb` file extension, containing Trinity source files inside a `lib/` directory and compiled Java files inside a `ext/` directory.  The compiler takes Java source files (`.java`) and compiles them to `.class` files, then bundles them with Trinity source files.  The loader unpacks these and interprets the contents.

This PR also adds batch/shell files for Trinity.