### PR TITLE
Add Range class

### DIFF
--- a/lib/Float.ty
+++ b/lib/Float.ty
@@ -15,3 +15,6 @@ module Trinity
         def native toString
 
         def native compareTo(other)
+
+        def next
+            this + 1

--- a/lib/Int.ty
+++ b/lib/Int.ty
@@ -17,3 +17,6 @@ module Trinity
         def native toHexString
 
         def native compareTo(other)
+
+        def next
+            this + 1

--- a/lib/Long.ty
+++ b/lib/Long.ty
@@ -17,3 +17,6 @@ module Trinity
         def native toHexString
 
         def native compareTo(other)
+
+        def next
+            this + 1

--- a/lib/Object.ty
+++ b/lib/Object.ty
@@ -14,6 +14,8 @@ module Trinity
 
         def native isInstance(instClass)
 
+        def native respondsTo(method)
+
         def secure hashCode
             System.identify(this)
 

--- a/lib/Range.ty
+++ b/lib/Range.ty
@@ -1,0 +1,41 @@
+module Trinity
+    class Range
+        def initialize(begin, end, excludeEnd = false)
+            @begin = begin
+            @end = end
+            @excludeEnd = excludeEnd
+
+        def getBegin
+            @begin
+
+        def getEnd
+            @end
+
+        def getExcludeEnd
+            @excludeEnd
+
+        def each(&block)
+            if !getBegin().respondsTo('next')
+                throw(Trinity.Errors.InvalidTypeError.new("Instances of '" + getBegin().getClass() + "' cannot be used to iterate over a " + getClass() + " instance because it does not define a 'next()' method."))
+
+            if block?
+                next = getBegin()
+                while next != getEnd()
+                    &block.call(next)
+                    next = next.next()
+                if !getExcludeEnd()
+                    &block.call(next)
+
+        def ==(other)
+            if !other.isInstance(Range)
+                return false
+            getBegin() == other.getBegin() && getEnd() == other.getEnd() && getExcludeEnd() == other.getExcludeEnd()
+
+        def toString
+            str = '(' + getBegin()
+            if getExcludeEnd()
+                str += '...'
+            else
+                str += '..'
+            str += getEnd() + ')'
+            str

--- a/lib/String.ty
+++ b/lib/String.ty
@@ -33,8 +33,14 @@ module Trinity
         def isEmpty
             length() == 0
 
-        def [](index)
-            chars()[index]
+        def [](obj)
+            if obj.isInstance(Range)
+                str = ''
+                obj.each() |e|
+                    str += chars()[e]
+                str
+            else
+                chars()[obj]
 
         def *(other)
             if other.isNumeric()

--- a/src/main/java/com/github/chrisblutz/trinity/interpreter/ExpressionInterpreter.java
+++ b/src/main/java/com/github/chrisblutz/trinity/interpreter/ExpressionInterpreter.java
@@ -352,6 +352,10 @@ public class ExpressionInterpreter {
                 return interpretUnaryNegation(errorClass, method, fileName, fullFile, lineNumber, tokens, nextBlock);
             }
             
+        } else if (TokenUtils.containsOnFirstLevel(tokens, Token.DOUBLE_DOT, Token.TRIPLE_DOT)) {
+            
+            return interpretRange(errorClass, method, fileName, fullFile, lineNumber, tokens, nextBlock);
+            
         } else if (nextBlock != null) {
             
             List<String> mandatoryParams = new ArrayList<>();
@@ -912,6 +916,25 @@ public class ExpressionInterpreter {
         return new ChainedInstructionSet(evaluators.toArray(new ObjectEvaluator[evaluators.size()]), fileName, fullFile, lineNumber);
     }
     
+    private static ChainedInstructionSet interpretRange(String errorClass, String method, String fileName, File fullFile, int lineNumber, TokenInfo[] tokens, Block nextBlock) {
+        
+        ChainedInstructionSet[] sets = new ChainedInstructionSet[2];
+        Token delimiter = Token.DOUBLE_DOT;
+        
+        if (TokenUtils.containsOnFirstLevel(tokens, Token.DOUBLE_DOT)) {
+            
+            delimiter = Token.DOUBLE_DOT;
+            sets = splitByToken(errorClass, method, fileName, fullFile, lineNumber, tokens, Token.DOUBLE_DOT, nextBlock);
+            
+        } else if (TokenUtils.containsOnFirstLevel(tokens, Token.TRIPLE_DOT)) {
+            
+            delimiter = Token.TRIPLE_DOT;
+            sets = splitByToken(errorClass, method, fileName, fullFile, lineNumber, tokens, Token.TRIPLE_DOT, nextBlock);
+        }
+        
+        return new ChainedInstructionSet(new ObjectEvaluator[]{new DoubleSetInstructionSet(DoubleSetInstructionSet.TokenSet.RANGE, sets[0], sets[1], delimiter, fileName, fullFile, lineNumber)}, fileName, fullFile, lineNumber);
+    }
+    
     private static class SplitResults {
         
         private TokenInfo[] tokens;
@@ -932,7 +955,6 @@ public class ExpressionInterpreter {
             
             return value;
         }
-        
     }
     
     private static SplitResults splitIntoTokensAndValue(String errorClass, String method, String fileName, File fullFile, int lineNumber, TokenInfo[] tokens, Token delimiter, Block nextBlock) {

--- a/src/main/java/com/github/chrisblutz/trinity/interpreter/instructionsets/DoubleSetInstructionSet.java
+++ b/src/main/java/com/github/chrisblutz/trinity/interpreter/instructionsets/DoubleSetInstructionSet.java
@@ -1,0 +1,79 @@
+package com.github.chrisblutz.trinity.interpreter.instructionsets;
+
+import com.github.chrisblutz.trinity.lang.TYObject;
+import com.github.chrisblutz.trinity.lang.scope.TYRuntime;
+import com.github.chrisblutz.trinity.natives.TrinityNatives;
+import com.github.chrisblutz.trinity.parser.tokens.Token;
+
+import java.io.File;
+
+
+/**
+ * @author Christopher Lutz
+ */
+public class DoubleSetInstructionSet extends ObjectEvaluator {
+    
+    public enum TokenSet {
+        
+        RANGE
+    }
+    
+    private TokenSet set;
+    private ChainedInstructionSet leftSet, rightSet;
+    private Token divider;
+    
+    public DoubleSetInstructionSet(TokenSet set, ChainedInstructionSet leftSet, ChainedInstructionSet rightSet, Token divider, String fileName, File fullFile, int lineNumber) {
+        
+        super(fileName, fullFile, lineNumber);
+        
+        this.set = set;
+        this.leftSet = leftSet;
+        this.rightSet = rightSet;
+        this.divider = divider;
+    }
+    
+    public TokenSet getSet() {
+        
+        return set;
+    }
+    
+    public ChainedInstructionSet getLeftSet() {
+        
+        return leftSet;
+    }
+    
+    public ChainedInstructionSet getRightSet() {
+        
+        return rightSet;
+    }
+    
+    public Token getDivider() {
+        
+        return divider;
+    }
+    
+    @Override
+    public TYObject evaluate(TYObject thisObj, TYRuntime runtime) {
+        
+        updateLocation();
+        
+        switch (set) {
+            
+            case RANGE:
+                
+                TYObject leftObj = getLeftSet().evaluate(TYObject.NONE, runtime);
+                TYObject rightObj = getRightSet().evaluate(TYObject.NONE, runtime);
+                boolean exclude = getDivider() == Token.TRIPLE_DOT;
+                
+                return TrinityNatives.newInstance("Trinity.Range", runtime, leftObj, rightObj, TrinityNatives.getObjectFor(exclude));
+        }
+        
+        return TYObject.NONE;
+    }
+    
+    @Override
+    public String toString(String indent) {
+        
+        return "MultiTokenInstructionSet [" + getSet() + "]";
+    }
+}

--- a/src/main/java/com/github/chrisblutz/trinity/lang/TYClass.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/TYClass.java
@@ -9,10 +9,7 @@ import com.github.chrisblutz.trinity.natives.NativeStorage;
 import com.github.chrisblutz.trinity.plugins.PluginLoader;
 import com.github.chrisblutz.trinity.plugins.api.Events;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 
 /**
@@ -32,6 +29,8 @@ public class TYClass {
     private Map<String, TYObject> variables = new HashMap<>();
     private List<ProcedureAction> initializationActions = new ArrayList<>();
     private boolean initialized = false;
+    
+    private List<String> callableMethods = new ArrayList<>();
     
     private String[] leadingComments = null;
     
@@ -62,6 +61,20 @@ public class TYClass {
         }
         
         return tree;
+    }
+    
+    private Set<String> compileCallableMethods() {
+        
+        Set<String> methods = new LinkedHashSet<>();
+        
+        methods.addAll(getMethodNames());
+        
+        if (superclass != null) {
+            
+            methods.addAll(superclass.compileCallableMethods());
+        }
+        
+        return methods;
     }
     
     public boolean hasVariable(String name) {
@@ -344,6 +357,16 @@ public class TYClass {
         return getMethods().getOrDefault(name, null);
     }
     
+    public Collection<String> getMethodNames() {
+        
+        return methods.keySet();
+    }
+    
+    public boolean respondsTo(String method) {
+        
+        return callableMethods.contains(method);
+    }
+    
     public String[] getLeadingComments() {
         
         return leadingComments;
@@ -412,5 +435,10 @@ public class TYClass {
             inheritanceTree = compileInheritanceTree();
             inheritanceTree.add(this);
         }
+        
+        
+        Set<String> callables = compileCallableMethods();
+        callableMethods = new ArrayList<>(callables);
+        Collections.sort(callableMethods);
     }
 }

--- a/src/main/java/com/github/chrisblutz/trinity/lang/types/nativeutils/NativeObject.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/types/nativeutils/NativeObject.java
@@ -3,6 +3,8 @@ package com.github.chrisblutz.trinity.lang.types.nativeutils;
 import com.github.chrisblutz.trinity.lang.TYClass;
 import com.github.chrisblutz.trinity.lang.TYObject;
 import com.github.chrisblutz.trinity.lang.procedures.DefaultProcedures;
+import com.github.chrisblutz.trinity.lang.procedures.ProcedureAction;
+import com.github.chrisblutz.trinity.lang.scope.TYRuntime;
 import com.github.chrisblutz.trinity.lang.types.TYClassObject;
 import com.github.chrisblutz.trinity.lang.types.TYStaticClassObject;
 import com.github.chrisblutz.trinity.lang.types.bool.TYBoolean;
@@ -43,6 +45,15 @@ class NativeObject {
             } else {
                 
                 return TYBoolean.FALSE;
+            }
+        });
+        TrinityNatives.registerMethod("Trinity.Object", "respondsTo", false, new String[]{"method"}, null, null, null, new ProcedureAction() {
+            
+            @Override
+            public TYObject onAction(TYRuntime runtime, TYObject thisObj, TYObject... params) {
+                
+                String method = TrinityNatives.toString(runtime.getVariable("method"), runtime);
+                return TrinityNatives.getObjectFor(thisObj.getObjectClass().respondsTo(method));
             }
         });
     }


### PR DESCRIPTION
This PR adds the `Trinity.Range` class, which allows traversal of values between two other values.  The Ruby-like syntax `x..x` and `x...x` is also supported.  The `next()` method has been implemented in the numeric classes to support traversal within ranges, and `String.[]` has been updated to support substrings using ranges.  In addition, `Object` now features a `respondsTo` method that allows programs to check whether an object will respond to a certain method or if an error will be thrown when the call is attempted.