### PR TITLE
Add basic multi-threading capabilities

### DIFF
--- a/lib/Kernel.ty
+++ b/lib/Kernel.ty
@@ -19,7 +19,8 @@ module Trinity
             $STDERR.println(message)
             exit(code)
 
-        def native static sleep(millis)
+        def static sleep(millis)
+            Thread.sleep(millis)
 
         def native static eval(code, args = {})
 

--- a/lib/Thread.ty
+++ b/lib/Thread.ty
@@ -1,0 +1,31 @@
+module Trinity
+    class Thread
+        def native initialize(&block, name = 'thread' + nextId())
+
+        def native start
+
+        def native interrupt
+
+        def native isAlive
+
+        def native isInterrupted
+
+        def native getName
+
+        def native setErrorHandler(&block)
+
+        def native getErrorHandler
+
+        def toString
+            getClass() + '[' + getName() + ']'
+
+        def native static current
+
+        def native static sleep(millis)
+
+        private
+            var nextAvailable = 0
+
+            def static nextId
+                nextAvailable += 1
+                nextAvailable

--- a/lib/errors/Error.ty
+++ b/lib/errors/Error.ty
@@ -2,13 +2,14 @@ module Trinity
     module Errors
         class Error
             private
-                var message, stackTrace
+                var message, stackTrace, thread
 
             public
                 def initialize(message)
                     this.message = message
 
                     stackTrace = populateStackTrace()
+                    thread = Thread.current()
 
                 def getMessage
                     message
@@ -17,7 +18,7 @@ module Trinity
                     stackTrace
 
                 def toString
-                    str = getClass().toString()
+                    str = 'Thread \'' + thread.getName() + '\' - ' + getClass().toString()
 
                     if !getMessage().isEmpty()
                         str += ': ' + getMessage()

--- a/src/main/java/com/github/chrisblutz/trinity/interpreter/ExpressionInterpreter.java
+++ b/src/main/java/com/github/chrisblutz/trinity/interpreter/ExpressionInterpreter.java
@@ -3,9 +3,9 @@ package com.github.chrisblutz.trinity.interpreter;
 import com.github.chrisblutz.trinity.interpreter.instructionsets.*;
 import com.github.chrisblutz.trinity.lang.TYObject;
 import com.github.chrisblutz.trinity.lang.errors.Errors;
-import com.github.chrisblutz.trinity.lang.errors.stacktrace.TrinityStack;
 import com.github.chrisblutz.trinity.lang.procedures.ProcedureAction;
 import com.github.chrisblutz.trinity.lang.procedures.TYProcedure;
+import com.github.chrisblutz.trinity.lang.threading.TYThread;
 import com.github.chrisblutz.trinity.parser.blocks.Block;
 import com.github.chrisblutz.trinity.parser.blocks.BlockLine;
 import com.github.chrisblutz.trinity.parser.lines.Line;
@@ -127,20 +127,21 @@ public class ExpressionInterpreter {
             
             TYObject returnObj = TYObject.NONE;
             
+            TYThread current = TYThread.getCurrentThread();
             for (ChainedInstructionSet set : sets) {
                 
                 if (!includeStackTrace) {
                     
-                    TrinityStack.pop();
+                    current.getTrinityStack().pop();
                 }
                 
-                TrinityStack.add(errorClass, method, set.getFileName(), set.getLineNumber());
+                current.getTrinityStack().add(errorClass, method, set.getFileName(), set.getLineNumber());
                 
                 TYObject result = set.evaluate(TYObject.NONE, runtime);
                 
                 if (includeStackTrace) {
                     
-                    TrinityStack.pop();
+                    current.getTrinityStack().pop();
                 }
                 
                 if (result != null && !runtime.isReturning()) {

--- a/src/main/java/com/github/chrisblutz/trinity/interpreter/defaults/ValInterpreter.java
+++ b/src/main/java/com/github/chrisblutz/trinity/interpreter/defaults/ValInterpreter.java
@@ -8,8 +8,8 @@ import com.github.chrisblutz.trinity.interpreter.instructionsets.ChainedInstruct
 import com.github.chrisblutz.trinity.lang.TYClass;
 import com.github.chrisblutz.trinity.lang.TYObject;
 import com.github.chrisblutz.trinity.lang.errors.Errors;
-import com.github.chrisblutz.trinity.lang.errors.stacktrace.TrinityStack;
 import com.github.chrisblutz.trinity.lang.procedures.ProcedureAction;
+import com.github.chrisblutz.trinity.lang.threading.TYThread;
 import com.github.chrisblutz.trinity.natives.TrinityNatives;
 import com.github.chrisblutz.trinity.parser.blocks.Block;
 import com.github.chrisblutz.trinity.parser.lines.Line;
@@ -96,11 +96,13 @@ public class ValInterpreter extends DeclarationInterpreter {
                             final TYClass container = containerClass;
                             action = (runtime, thisObj, params) -> {
                                 
-                                TrinityStack.add(container.getName(), "<nil>", fileName, line.getLineNumber());
+                                TYThread current = TYThread.getCurrentThread();
+                                
+                                current.getTrinityStack().add(container.getName(), "<nil>", fileName, line.getLineNumber());
                                 
                                 TYObject result = set.evaluate(TYObject.NONE, runtime);
                                 
-                                TrinityStack.pop();
+                                current.getTrinityStack().pop();
                                 
                                 return result;
                             };

--- a/src/main/java/com/github/chrisblutz/trinity/interpreter/defaults/VarInterpreter.java
+++ b/src/main/java/com/github/chrisblutz/trinity/interpreter/defaults/VarInterpreter.java
@@ -8,8 +8,8 @@ import com.github.chrisblutz.trinity.interpreter.instructionsets.ChainedInstruct
 import com.github.chrisblutz.trinity.lang.TYClass;
 import com.github.chrisblutz.trinity.lang.TYObject;
 import com.github.chrisblutz.trinity.lang.errors.Errors;
-import com.github.chrisblutz.trinity.lang.errors.stacktrace.TrinityStack;
 import com.github.chrisblutz.trinity.lang.procedures.ProcedureAction;
+import com.github.chrisblutz.trinity.lang.threading.TYThread;
 import com.github.chrisblutz.trinity.natives.TrinityNatives;
 import com.github.chrisblutz.trinity.parser.blocks.Block;
 import com.github.chrisblutz.trinity.parser.lines.Line;
@@ -96,11 +96,13 @@ public class VarInterpreter extends DeclarationInterpreter {
                             final TYClass container = containerClass;
                             action = (runtime, thisObj, params) -> {
                                 
-                                TrinityStack.add(container.getName(), "<nil>", fileName, line.getLineNumber());
+                                TYThread current = TYThread.getCurrentThread();
+                                
+                                current.getTrinityStack().add(container.getName(), "<nil>", fileName, line.getLineNumber());
                                 
                                 TYObject result = set.evaluate(TYObject.NONE, runtime);
                                 
-                                TrinityStack.pop();
+                                current.getTrinityStack().pop();
                                 
                                 return result;
                             };

--- a/src/main/java/com/github/chrisblutz/trinity/interpreter/instructionsets/TryInstructionSet.java
+++ b/src/main/java/com/github/chrisblutz/trinity/interpreter/instructionsets/TryInstructionSet.java
@@ -3,9 +3,9 @@ package com.github.chrisblutz.trinity.interpreter.instructionsets;
 import com.github.chrisblutz.trinity.interpreter.errors.TrinityErrorException;
 import com.github.chrisblutz.trinity.lang.TYObject;
 import com.github.chrisblutz.trinity.lang.errors.Errors;
-import com.github.chrisblutz.trinity.lang.errors.stacktrace.TrinityStack;
 import com.github.chrisblutz.trinity.lang.procedures.ProcedureAction;
 import com.github.chrisblutz.trinity.lang.scope.TYRuntime;
+import com.github.chrisblutz.trinity.lang.threading.TYThread;
 import com.github.chrisblutz.trinity.plugins.PluginLoader;
 import com.github.chrisblutz.trinity.plugins.api.Events;
 
@@ -61,7 +61,7 @@ public class TryInstructionSet extends ChainedInstructionSet {
         
         TYObject result = TYObject.NONE;
         
-        int stackDepth = TrinityStack.size();
+        int stackDepth = TYThread.getCurrentThread().getTrinityStack().size();
         try {
             
             if (getAction() != null) {
@@ -75,7 +75,7 @@ public class TryInstructionSet extends ChainedInstructionSet {
             // These are normally removed after an instruction set completes,
             // but since this instruction set exited with an error, its
             // corresponding stack elements were not removed.
-            TrinityStack.popToSize(stackDepth);
+            TYThread.getCurrentThread().getTrinityStack().popToSize(stackDepth);
             
             PluginLoader.triggerEvent(Events.ERROR_CAUGHT, e.getErrorObject(), getFileName(), getLineNumber());
             

--- a/src/main/java/com/github/chrisblutz/trinity/lang/TYClass.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/TYClass.java
@@ -8,6 +8,7 @@ import com.github.chrisblutz.trinity.lang.scope.TYRuntime;
 import com.github.chrisblutz.trinity.lang.variables.VariableLoc;
 import com.github.chrisblutz.trinity.lang.variables.VariableManager;
 import com.github.chrisblutz.trinity.natives.NativeStorage;
+import com.github.chrisblutz.trinity.natives.TrinityNatives;
 import com.github.chrisblutz.trinity.plugins.PluginLoader;
 import com.github.chrisblutz.trinity.plugins.api.Events;
 
@@ -370,7 +371,7 @@ public class TYClass {
                         
                         Errors.throwError("Trinity.Errors.ReturnError", runtime, "Cannot return a value from a constructor.");
                         
-                    } else if (obj.getObjectClass().isInstanceOf(ClassRegistry.getClass("Trinity.Map")) || obj.getObjectClass().isInstanceOf(ClassRegistry.getClass("Trinity.Procedure"))) {
+                    } else if (TrinityNatives.isClassNativelyConstructed(newObj.getObjectClass()) && TrinityNatives.isClassNativelyConstructed(obj.getObjectClass())) {
                         
                         newObj = obj;
                     }

--- a/src/main/java/com/github/chrisblutz/trinity/lang/errors/Errors.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/errors/Errors.java
@@ -5,8 +5,8 @@ import com.github.chrisblutz.trinity.cli.CLI;
 import com.github.chrisblutz.trinity.interpreter.errors.TrinityErrorException;
 import com.github.chrisblutz.trinity.lang.TYObject;
 import com.github.chrisblutz.trinity.lang.errors.stacktrace.StackElement;
-import com.github.chrisblutz.trinity.lang.errors.stacktrace.TrinityStack;
 import com.github.chrisblutz.trinity.lang.scope.TYRuntime;
+import com.github.chrisblutz.trinity.lang.threading.TYThread;
 import com.github.chrisblutz.trinity.lang.types.strings.TYString;
 import com.github.chrisblutz.trinity.natives.TrinityNatives;
 
@@ -60,7 +60,7 @@ public class Errors {
     public static void throwUnrecoverable(String errorClass, Object... args) {
         
         TYObject error = constructError(errorClass, new TYRuntime(), args);
-        throwUncaughtJavaException(new TrinityErrorException(error), null, 0);
+        throwUncaughtJavaException(new TrinityErrorException(error), null, 0, TYThread.getCurrentThread());
     }
     
     private static TYObject constructError(String errorClass, TYRuntime runtime, Object... args) {
@@ -83,7 +83,7 @@ public class Errors {
         return TrinityNatives.newInstance(errorClass, runtime, tyArgs);
     }
     
-    public static void throwUncaughtJavaException(Throwable error, String file, int line) {
+    public static void throwUncaughtJavaException(Throwable error, String file, int line, TYThread thread) {
         
         if (error instanceof TrinityErrorException) {
             
@@ -98,7 +98,7 @@ public class Errors {
             
         } else {
             
-            System.err.println("An error occurred in the Trinity interpreter in file '" + file + "' at line " + line + ".");
+            System.err.println("An error occurred in the Trinity interpreter in file '" + file + "' at line " + line + " on thread '" + thread.getName() + "'.");
             
             if (CLI.isDebuggingEnabled()) {
                 
@@ -106,7 +106,7 @@ public class Errors {
                 error.printStackTrace();
                 
                 System.err.println("\n== FULL TRINITY STACK ==\n");
-                for(StackElement element : TrinityStack.getStack()){
+                for (StackElement element : thread.getTrinityStack().getStack()) {
                     
                     System.err.println(element);
                 }

--- a/src/main/java/com/github/chrisblutz/trinity/lang/errors/stacktrace/TrinityStack.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/errors/stacktrace/TrinityStack.java
@@ -1,6 +1,7 @@
 package com.github.chrisblutz.trinity.lang.errors.stacktrace;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -9,24 +10,32 @@ import java.util.List;
  */
 public class TrinityStack {
     
-    private static List<StackElement> stack = new ArrayList<>();
+    private List<StackElement> stack = new ArrayList<>();
     
-    public static void add(String errorClass, String method, String file, int line) {
+    public TrinityStack(TrinityStack parent) {
+        
+        if (parent != null) {
+            
+            Collections.addAll(stack, parent.getStack());
+        }
+    }
+    
+    public void add(String errorClass, String method, String file, int line) {
         
         stack.add(0, new StackElement(errorClass, method, file, line));
     }
     
-    public static void pop() {
+    public void pop() {
         
         stack.remove(0);
     }
     
-    public static int size() {
+    public int size() {
         
         return stack.size();
     }
     
-    public static void popToSize(int size) {
+    public void popToSize(int size) {
         
         while (size() > size) {
             
@@ -34,7 +43,7 @@ public class TrinityStack {
         }
     }
     
-    public static StackElement[] getStack() {
+    public StackElement[] getStack() {
         
         return stack.toArray(new StackElement[stack.size()]);
     }

--- a/src/main/java/com/github/chrisblutz/trinity/lang/threading/TYThread.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/threading/TYThread.java
@@ -1,0 +1,135 @@
+package com.github.chrisblutz.trinity.lang.threading;
+
+import com.github.chrisblutz.trinity.Trinity;
+import com.github.chrisblutz.trinity.interpreter.errors.TrinityErrorException;
+import com.github.chrisblutz.trinity.lang.TYObject;
+import com.github.chrisblutz.trinity.lang.errors.Errors;
+import com.github.chrisblutz.trinity.lang.errors.stacktrace.TrinityStack;
+import com.github.chrisblutz.trinity.lang.procedures.TYProcedure;
+import com.github.chrisblutz.trinity.lang.scope.TYRuntime;
+import com.github.chrisblutz.trinity.lang.types.procedures.TYProcedureObject;
+import com.github.chrisblutz.trinity.runner.Runner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * @author Christopher Lutz
+ */
+public class TYThread {
+    
+    private static Map<Thread, TYThread> threads = new HashMap<>();
+    
+    private String name;
+    private Thread thread;
+    
+    private TrinityStack trinityStack;
+    
+    private TYProcedureObject errorHandler = null;
+    
+    public TYThread(String name, TYProcedure procedure, TYRuntime runtime) {
+        
+        this.name = name;
+        thread = new Thread(Runner.getTrinityThreadGroup(), () -> {
+            
+            if (runtime != null) {
+                
+                TYRuntime newRuntime = runtime.clone();
+                procedure.call(newRuntime, null, null, TYObject.NONE);
+            }
+        });
+        thread.setUncaughtExceptionHandler((t, e) -> {
+            
+            TYThread tyThread = TYThread.getThread(t);
+            
+            if (errorHandler != null && e instanceof TrinityErrorException) {
+                
+                try {
+                    
+                    errorHandler.getInternalProcedure().call(errorHandler.getProcedureRuntime(), null, null, TYObject.NONE, ((TrinityErrorException) e).getErrorObject());
+                    
+                } catch (Exception e2) {
+                    
+                    Errors.throwUncaughtJavaException(e2, Runner.getCurrentFile(thread), Runner.getCurrentLine(thread), tyThread);
+                    
+                    Trinity.exit(1);
+                }
+                
+            } else {
+                
+                Errors.throwUncaughtJavaException(e, Runner.getCurrentFile(thread), Runner.getCurrentLine(thread), tyThread);
+                
+                Trinity.exit(1);
+            }
+        });
+        thread.setName(name);
+        
+        trinityStack = new TrinityStack(null);
+        
+        threads.put(thread, this);
+    }
+    
+    public void start() {
+        
+        TrinityStack parent = null;
+        TYThread current = getCurrentThread();
+        if (current != null) {
+            
+            parent = current.getTrinityStack();
+        }
+        trinityStack = new TrinityStack(parent);
+        
+        thread.start();
+    }
+    
+    public void interrupt() {
+        
+        thread.interrupt();
+    }
+    
+    public boolean isAlive() {
+        
+        return thread.isAlive();
+    }
+    
+    public boolean isInterrupted() {
+        
+        return thread.isInterrupted();
+    }
+    
+    public String getName() {
+        
+        return name;
+    }
+    
+    public void setErrorHandler(TYProcedureObject errorHandler) {
+        
+        this.errorHandler = errorHandler;
+    }
+    
+    public TYProcedureObject getErrorHandler() {
+        
+        return errorHandler;
+    }
+    
+    public TrinityStack getTrinityStack() {
+        
+        return trinityStack;
+    }
+    
+    public static TYThread getThread(Thread thread) {
+        
+        return threads.get(thread);
+    }
+    
+    public static TYThread getCurrentThread() {
+        
+        return getThread(Thread.currentThread());
+    }
+    
+    public static TYThread constructMainThread(TYProcedure procedure) {
+        
+        return new TYThread("main", procedure, new TYRuntime());
+    }
+}

--- a/src/main/java/com/github/chrisblutz/trinity/lang/types/nativeutils/NativeErrors.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/types/nativeutils/NativeErrors.java
@@ -3,6 +3,7 @@ package com.github.chrisblutz.trinity.lang.types.nativeutils;
 import com.github.chrisblutz.trinity.lang.TYObject;
 import com.github.chrisblutz.trinity.lang.errors.stacktrace.StackElement;
 import com.github.chrisblutz.trinity.lang.errors.stacktrace.TrinityStack;
+import com.github.chrisblutz.trinity.lang.threading.TYThread;
 import com.github.chrisblutz.trinity.lang.types.arrays.TYArray;
 import com.github.chrisblutz.trinity.lang.types.numeric.TYInt;
 import com.github.chrisblutz.trinity.lang.types.strings.TYString;
@@ -22,9 +23,10 @@ class NativeErrors {
             
             TYArray ary = new TYArray(new ArrayList<>());
             
-            for (int i = 2 + thisObj.getSuperStackLevel(); i < TrinityStack.getStack().length; i++) {
+            TrinityStack stack = TYThread.getCurrentThread().getTrinityStack();
+            for (int i = 2 + thisObj.getSuperStackLevel(); i < stack.getStack().length; i++) {
                 
-                StackElement e = TrinityStack.getStack()[i];
+                StackElement e = stack.getStack()[i];
                 
                 TYObject errorClass;
                 if (e.getErrorClass() != null) {

--- a/src/main/java/com/github/chrisblutz/trinity/lang/types/nativeutils/NativeHelper.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/types/nativeutils/NativeHelper.java
@@ -25,6 +25,8 @@ public class NativeHelper {
         NativeKernel.register();
         NativeSystem.register();
         
+        NativeThread.register();
+        
         NativeErrors.register();
         NativeFileSystem.register();
         NativeProcedure.register();

--- a/src/main/java/com/github/chrisblutz/trinity/lang/types/nativeutils/NativeMap.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/types/nativeutils/NativeMap.java
@@ -17,6 +17,8 @@ class NativeMap {
     
     static void register() {
         
+        TrinityNatives.registerForNativeConstruction("Trinity.Map");
+        
         TrinityNatives.registerMethod("Trinity.Map", "initialize", (runtime, thisObj, params) -> new TYMap(new HashMap<>()));
         TrinityNatives.registerMethod("Trinity.Map", "length", (runtime, thisObj, params) -> NativeStorage.getMapLength(TrinityNatives.cast(TYMap.class, thisObj)));
         TrinityNatives.registerMethod("Trinity.Map", "keys", (runtime, thisObj, params) -> NativeStorage.getMapKeySet(TrinityNatives.cast(TYMap.class, thisObj)));

--- a/src/main/java/com/github/chrisblutz/trinity/lang/types/nativeutils/NativeProcedure.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/types/nativeutils/NativeProcedure.java
@@ -19,6 +19,8 @@ class NativeProcedure {
     
     static void register() {
         
+        TrinityNatives.registerForNativeConstruction("Trinity.Procedure");
+        
         TrinityNatives.registerMethod("Trinity.Procedure", "initialize", (runtime, thisObj, params) -> {
             
             if (runtime.hasVariable("block")) {

--- a/src/main/java/com/github/chrisblutz/trinity/lang/types/nativeutils/NativeThread.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/types/nativeutils/NativeThread.java
@@ -1,0 +1,90 @@
+package com.github.chrisblutz.trinity.lang.types.nativeutils;
+
+import com.github.chrisblutz.trinity.lang.TYObject;
+import com.github.chrisblutz.trinity.lang.procedures.TYProcedure;
+import com.github.chrisblutz.trinity.lang.threading.TYThread;
+import com.github.chrisblutz.trinity.lang.types.bool.TYBoolean;
+import com.github.chrisblutz.trinity.lang.types.procedures.TYProcedureObject;
+import com.github.chrisblutz.trinity.lang.types.threading.TYThreadObject;
+import com.github.chrisblutz.trinity.natives.NativeStorage;
+import com.github.chrisblutz.trinity.natives.TrinityNatives;
+
+
+/**
+ * @author Christopher Lutz
+ */
+class NativeThread {
+    
+    static void register() {
+        
+        TrinityNatives.registerForNativeConstruction("Trinity.Thread");
+        
+        TrinityNatives.registerMethod("Trinity.Thread", "initialize", (runtime, thisObj, params) -> {
+            
+            TYProcedure procedure = TrinityNatives.cast(TYProcedureObject.class, runtime.getVariable("block")).getInternalProcedure();
+            String name = TrinityNatives.toString(runtime.getVariable("name"), runtime);
+            
+            return new TYThreadObject(new TYThread(name, procedure, runtime));
+        });
+        TrinityNatives.registerMethod("Trinity.Thread", "start", (runtime, thisObj, params) -> {
+            
+            TYThread thread = TrinityNatives.cast(TYThreadObject.class, thisObj).getInternalThread();
+            thread.start();
+            return TYObject.NONE;
+        });
+        TrinityNatives.registerMethod("Trinity.Thread", "interrupt", (runtime, thisObj, params) -> {
+            
+            TYThread thread = TrinityNatives.cast(TYThreadObject.class, thisObj).getInternalThread();
+            thread.interrupt();
+            return TYObject.NONE;
+        });
+        TrinityNatives.registerMethod("Trinity.Thread", "isAlive", (runtime, thisObj, params) -> {
+            
+            TYThread thread = TrinityNatives.cast(TYThreadObject.class, thisObj).getInternalThread();
+            return TYBoolean.valueFor(thread.isAlive());
+        });
+        TrinityNatives.registerMethod("Trinity.Thread", "isInterrupted", (runtime, thisObj, params) -> {
+            
+            TYThread thread = TrinityNatives.cast(TYThreadObject.class, thisObj).getInternalThread();
+            return TYBoolean.valueFor(thread.isInterrupted());
+        });
+        TrinityNatives.registerMethod("Trinity.Thread", "getName", (runtime, thisObj, params) -> {
+            
+            TYThread thread = TrinityNatives.cast(TYThreadObject.class, thisObj).getInternalThread();
+            return TrinityNatives.getObjectFor(thread.getName());
+        });
+        TrinityNatives.registerMethod("Trinity.Thread", "setErrorHandler", (runtime, thisObj, params) -> {
+            
+            TYThread thread = TrinityNatives.cast(TYThreadObject.class, thisObj).getInternalThread();
+            thread.setErrorHandler(TrinityNatives.cast(TYProcedureObject.class, runtime.getVariable("block")));
+            return TYObject.NONE;
+        });
+        TrinityNatives.registerMethod("Trinity.Thread", "getErrorHandler", (runtime, thisObj, params) -> {
+            
+            TYThread thread = TrinityNatives.cast(TYThreadObject.class, thisObj).getInternalThread();
+            if (thread.getErrorHandler() != null) {
+                
+                return thread.getErrorHandler();
+                
+            } else {
+                
+                return TYObject.NIL;
+            }
+        });
+        
+        TrinityNatives.registerMethod("Trinity.Thread", "current", (runtime, thisObj, params) -> NativeStorage.getThreadObject(TYThread.getCurrentThread()));
+        TrinityNatives.registerMethod("Trinity.Thread", "sleep", (runtime, thisObj, params) -> {
+            
+            long millis = TrinityNatives.toLong(runtime.getVariable("millis"));
+            try {
+                
+                Thread.sleep(millis);
+                
+            } catch (InterruptedException e) {
+                
+                // TODO
+            }
+            return TYObject.NONE;
+        });
+    }
+}

--- a/src/main/java/com/github/chrisblutz/trinity/lang/types/threading/TYThreadObject.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/types/threading/TYThreadObject.java
@@ -1,0 +1,26 @@
+package com.github.chrisblutz.trinity.lang.types.threading;
+
+import com.github.chrisblutz.trinity.lang.ClassRegistry;
+import com.github.chrisblutz.trinity.lang.TYObject;
+import com.github.chrisblutz.trinity.lang.threading.TYThread;
+
+
+/**
+ * @author Christopher Lutz
+ */
+public class TYThreadObject extends TYObject {
+    
+    private TYThread internalThread;
+    
+    public TYThreadObject(TYThread internal) {
+        
+        super(ClassRegistry.getClass("Trinity.Thread"));
+        
+        this.internalThread = internal;
+    }
+    
+    public TYThread getInternalThread() {
+    
+        return internalThread;
+    }
+}

--- a/src/main/java/com/github/chrisblutz/trinity/natives/NativeStorage.java
+++ b/src/main/java/com/github/chrisblutz/trinity/natives/NativeStorage.java
@@ -5,6 +5,7 @@ import com.github.chrisblutz.trinity.lang.TYMethod;
 import com.github.chrisblutz.trinity.lang.TYModule;
 import com.github.chrisblutz.trinity.lang.TYObject;
 import com.github.chrisblutz.trinity.lang.procedures.TYProcedure;
+import com.github.chrisblutz.trinity.lang.threading.TYThread;
 import com.github.chrisblutz.trinity.lang.types.*;
 import com.github.chrisblutz.trinity.lang.types.arrays.TYArray;
 import com.github.chrisblutz.trinity.lang.types.bool.TYBoolean;
@@ -12,6 +13,7 @@ import com.github.chrisblutz.trinity.lang.types.maps.TYMap;
 import com.github.chrisblutz.trinity.lang.types.numeric.TYFloat;
 import com.github.chrisblutz.trinity.lang.types.numeric.TYInt;
 import com.github.chrisblutz.trinity.lang.types.strings.TYString;
+import com.github.chrisblutz.trinity.lang.types.threading.TYThreadObject;
 
 import java.util.*;
 
@@ -60,10 +62,12 @@ public class NativeStorage {
     private static Map<TYModule, TYObject> moduleLeadingComments = new HashMap<>();
     private static Map<TYMethod, TYObject> methodLeadingComments = new HashMap<>();
     
+    private static Map<TYThread, TYThreadObject> threadObjectMap = new HashMap<>();
+    
     private static TYString nilString = null;
     private static TYFloat e = null, pi = null;
     
-    public static TYClassObject getClassObject(TYClass tyClass) {
+    public synchronized static TYClassObject getClassObject(TYClass tyClass) {
         
         if (!classObjects.containsKey(tyClass)) {
             
@@ -73,7 +77,7 @@ public class NativeStorage {
         return classObjects.get(tyClass);
     }
     
-    public static TYStaticClassObject getStaticClassObject(TYClass tyClass) {
+    public synchronized static TYStaticClassObject getStaticClassObject(TYClass tyClass) {
         
         if (!staticClassObjects.containsKey(tyClass)) {
             
@@ -83,7 +87,7 @@ public class NativeStorage {
         return staticClassObjects.get(tyClass);
     }
     
-    public static TYModuleObject getModuleObject(TYModule tyModule) {
+    public synchronized static TYModuleObject getModuleObject(TYModule tyModule) {
         
         if (!moduleObjects.containsKey(tyModule)) {
             
@@ -93,7 +97,7 @@ public class NativeStorage {
         return moduleObjects.get(tyModule);
     }
     
-    public static TYStaticModuleObject getStaticModuleObject(TYModule tyModule) {
+    public synchronized static TYStaticModuleObject getStaticModuleObject(TYModule tyModule) {
         
         if (!staticModuleObjects.containsKey(tyModule)) {
             
@@ -103,7 +107,7 @@ public class NativeStorage {
         return staticModuleObjects.get(tyModule);
     }
     
-    public static TYMethodObject getMethodObject(TYMethod tyMethod) {
+    public synchronized static TYMethodObject getMethodObject(TYMethod tyMethod) {
         
         if (!methodObjects.containsKey(tyMethod)) {
             
@@ -113,7 +117,7 @@ public class NativeStorage {
         return methodObjects.get(tyMethod);
     }
     
-    public static TYString getClassName(TYClass tyClass) {
+    public synchronized static TYString getClassName(TYClass tyClass) {
         
         if (!classNames.containsKey(tyClass)) {
             
@@ -123,7 +127,7 @@ public class NativeStorage {
         return classNames.get(tyClass);
     }
     
-    public static TYString getClassShortName(TYClass tyClass) {
+    public synchronized static TYString getClassShortName(TYClass tyClass) {
         
         if (!classShortNames.containsKey(tyClass)) {
             
@@ -133,7 +137,7 @@ public class NativeStorage {
         return classShortNames.get(tyClass);
     }
     
-    public static TYString getModuleName(TYModule tyModule) {
+    public synchronized static TYString getModuleName(TYModule tyModule) {
         
         if (!moduleNames.containsKey(tyModule)) {
             
@@ -143,7 +147,7 @@ public class NativeStorage {
         return moduleNames.get(tyModule);
     }
     
-    public static TYString getModuleShortName(TYModule tyModule) {
+    public synchronized static TYString getModuleShortName(TYModule tyModule) {
         
         if (!moduleShortNames.containsKey(tyModule)) {
             
@@ -153,7 +157,7 @@ public class NativeStorage {
         return moduleShortNames.get(tyModule);
     }
     
-    public static TYString getMethodName(TYMethod tyMethod) {
+    public synchronized static TYString getMethodName(TYMethod tyMethod) {
         
         if (!methodNames.containsKey(tyMethod)) {
             
@@ -163,7 +167,7 @@ public class NativeStorage {
         return methodNames.get(tyMethod);
     }
     
-    public static TYBoolean isMethodStatic(TYMethod tyMethod) {
+    public synchronized static TYBoolean isMethodStatic(TYMethod tyMethod) {
         
         if (!methodStatic.containsKey(tyMethod)) {
             
@@ -173,7 +177,7 @@ public class NativeStorage {
         return methodStatic.get(tyMethod);
     }
     
-    public static TYBoolean isMethodNative(TYMethod tyMethod) {
+    public synchronized static TYBoolean isMethodNative(TYMethod tyMethod) {
         
         if (!methodNative.containsKey(tyMethod)) {
             
@@ -183,7 +187,7 @@ public class NativeStorage {
         return methodNative.get(tyMethod);
     }
     
-    public static TYBoolean isMethodSecure(TYMethod tyMethod) {
+    public synchronized static TYBoolean isMethodSecure(TYMethod tyMethod) {
         
         if (!methodSecure.containsKey(tyMethod)) {
             
@@ -193,7 +197,7 @@ public class NativeStorage {
         return methodSecure.get(tyMethod);
     }
     
-    public static TYArray getMandatoryArguments(TYProcedure tyProcedure) {
+    public synchronized static TYArray getMandatoryArguments(TYProcedure tyProcedure) {
         
         if (!mandatoryArguments.containsKey(tyProcedure)) {
             
@@ -205,7 +209,7 @@ public class NativeStorage {
         return mandatoryArguments.get(tyProcedure);
     }
     
-    public static TYArray getOptionalArguments(TYProcedure tyProcedure) {
+    public synchronized static TYArray getOptionalArguments(TYProcedure tyProcedure) {
         
         if (!optionalArguments.containsKey(tyProcedure)) {
             
@@ -217,7 +221,7 @@ public class NativeStorage {
         return optionalArguments.get(tyProcedure);
     }
     
-    public static TYObject getBlockArgument(TYProcedure tyProcedure) {
+    public synchronized static TYObject getBlockArgument(TYProcedure tyProcedure) {
         
         if (!blockArguments.containsKey(tyProcedure)) {
             
@@ -227,7 +231,7 @@ public class NativeStorage {
         return blockArguments.get(tyProcedure);
     }
     
-    public static TYObject getOverflowArgument(TYProcedure tyProcedure) {
+    public synchronized static TYObject getOverflowArgument(TYProcedure tyProcedure) {
         
         if (!overflowArguments.containsKey(tyProcedure)) {
             
@@ -237,7 +241,7 @@ public class NativeStorage {
         return overflowArguments.get(tyProcedure);
     }
     
-    public static TYInt getArrayLength(TYArray tyArray) {
+    public synchronized static TYInt getArrayLength(TYArray tyArray) {
         
         if (!arrayLengths.containsKey(tyArray)) {
             
@@ -247,12 +251,12 @@ public class NativeStorage {
         return arrayLengths.get(tyArray);
     }
     
-    public static void clearArrayData(TYArray tyArray) {
+    public synchronized static void clearArrayData(TYArray tyArray) {
         
         arrayLengths.remove(tyArray);
     }
     
-    public static TYArray getMapKeySet(TYMap tyMap) {
+    public synchronized static TYArray getMapKeySet(TYMap tyMap) {
         
         if (!mapKeySets.containsKey(tyMap)) {
             
@@ -264,7 +268,7 @@ public class NativeStorage {
         return mapKeySets.get(tyMap);
     }
     
-    public static TYArray getMapValues(TYMap tyMap) {
+    public synchronized static TYArray getMapValues(TYMap tyMap) {
         
         if (!mapValues.containsKey(tyMap)) {
             
@@ -276,7 +280,7 @@ public class NativeStorage {
         return mapValues.get(tyMap);
     }
     
-    public static TYInt getMapLength(TYMap tyMap) {
+    public synchronized static TYInt getMapLength(TYMap tyMap) {
         
         if (!mapLengths.containsKey(tyMap)) {
             
@@ -286,14 +290,14 @@ public class NativeStorage {
         return mapLengths.get(tyMap);
     }
     
-    public static void clearMapData(TYMap tyMap) {
+    public synchronized static void clearMapData(TYMap tyMap) {
         
         mapKeySets.remove(tyMap);
         mapValues.remove(tyMap);
         mapLengths.remove(tyMap);
     }
     
-    public static TYInt getHashCode(TYObject tyObject) {
+    public synchronized static TYInt getHashCode(TYObject tyObject) {
         
         if (!hashCodes.containsKey(tyObject)) {
             
@@ -303,7 +307,7 @@ public class NativeStorage {
         return hashCodes.get(tyObject);
     }
     
-    public static TYString getNilString() {
+    public synchronized static TYString getNilString() {
         
         if (nilString == null) {
             
@@ -313,7 +317,7 @@ public class NativeStorage {
         return nilString;
     }
     
-    public static TYObject getLeadingComments(TYClass tyClass) {
+    public synchronized static TYObject getLeadingComments(TYClass tyClass) {
         
         if (!classLeadingComments.containsKey(tyClass)) {
             
@@ -324,7 +328,7 @@ public class NativeStorage {
         return classLeadingComments.get(tyClass);
     }
     
-    public static TYObject getLeadingComments(TYModule tyModule) {
+    public synchronized static TYObject getLeadingComments(TYModule tyModule) {
         
         if (!moduleLeadingComments.containsKey(tyModule)) {
             
@@ -335,7 +339,7 @@ public class NativeStorage {
         return moduleLeadingComments.get(tyModule);
     }
     
-    public static TYObject getLeadingComments(TYMethod tyMethod) {
+    public synchronized static TYObject getLeadingComments(TYMethod tyMethod) {
         
         if (!methodLeadingComments.containsKey(tyMethod)) {
             
@@ -346,7 +350,17 @@ public class NativeStorage {
         return methodLeadingComments.get(tyMethod);
     }
     
-    public static TYFloat getE() {
+    public synchronized static TYThreadObject getThreadObject(TYThread tyThread) {
+        
+        if (!threadObjectMap.containsKey(tyThread)) {
+            
+            threadObjectMap.put(tyThread, new TYThreadObject(tyThread));
+        }
+        
+        return threadObjectMap.get(tyThread);
+    }
+    
+    public synchronized static TYFloat getE() {
         
         if (e == null) {
             
@@ -356,7 +370,7 @@ public class NativeStorage {
         return e;
     }
     
-    public static TYFloat getPi() {
+    public synchronized static TYFloat getPi() {
         
         if (pi == null) {
             


### PR DESCRIPTION
This PR introduces the `Trinity.Thread` class, which supports basic multi-threading capabilities.  The `Thread` class is supported on the native side by Java's threading API, and supports uncaught error handlers.