### PR TITLE
Add support for interfaces

### DIFF
--- a/src/main/java/com/github/chrisblutz/trinity/interpreter/actions/ExpressionProcedureAction.java
+++ b/src/main/java/com/github/chrisblutz/trinity/interpreter/actions/ExpressionProcedureAction.java
@@ -2,8 +2,8 @@ package com.github.chrisblutz.trinity.interpreter.actions;
 
 import com.github.chrisblutz.trinity.interpreter.instructions.InstructionSet;
 import com.github.chrisblutz.trinity.lang.TYObject;
-import com.github.chrisblutz.trinity.lang.procedures.ProcedureAction;
 import com.github.chrisblutz.trinity.lang.TYRuntime;
+import com.github.chrisblutz.trinity.lang.procedures.ProcedureAction;
 import com.github.chrisblutz.trinity.lang.threading.TYThread;
 
 

--- a/src/main/java/com/github/chrisblutz/trinity/interpreter/actions/InterfaceMethodProcedureAction.java
+++ b/src/main/java/com/github/chrisblutz/trinity/interpreter/actions/InterfaceMethodProcedureAction.java
@@ -1,0 +1,27 @@
+package com.github.chrisblutz.trinity.interpreter.actions;
+
+import com.github.chrisblutz.trinity.lang.TYObject;
+import com.github.chrisblutz.trinity.lang.TYRuntime;
+import com.github.chrisblutz.trinity.lang.errors.Errors;
+import com.github.chrisblutz.trinity.lang.procedures.ProcedureAction;
+
+
+/**
+ * @author Christopher Lutz
+ */
+public class InterfaceMethodProcedureAction implements ProcedureAction {
+    
+    private String methodName;
+    
+    public InterfaceMethodProcedureAction(String methodName) {
+        
+        this.methodName = methodName;
+    }
+    
+    @Override
+    public TYObject onAction(TYRuntime runtime, TYObject thisObj, TYObject... params) {
+        
+        Errors.throwError(Errors.Classes.SCOPE_ERROR, runtime, "Cannot call interface method '" + methodName + "'.");
+        return TYObject.NONE;
+    }
+}

--- a/src/main/java/com/github/chrisblutz/trinity/interpreter/facets/OperatorFacets.java
+++ b/src/main/java/com/github/chrisblutz/trinity/interpreter/facets/OperatorFacets.java
@@ -183,7 +183,7 @@ public class OperatorFacets {
                 return first.tyInvoke("<<", runtime, null, null, second);
             }
         };
-        BinaryOperator bitShiftRight = new BinaryOperator(Token.BIT_SHIFT_RIGHT) {
+        BinaryOperator bitShiftRight = new BinaryOperator(Token.INTERFACE_IMPLEMENTATION) {
             
             @Override
             public TYObject operate(TYObject first, TYObject second, TYRuntime runtime) {

--- a/src/main/java/com/github/chrisblutz/trinity/lang/TYClass.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/TYClass.java
@@ -668,7 +668,7 @@ public class TYClass {
                 TYClass superclass = module.getClass(superclassString);
                 if (superclass.isInterface()) {
                     
-                    Runner.setPostFinalizeError(Errors.Classes.INHERITANCE_ERROR, "Cannot extend interface " + superclassString + ".  Use the >> implementation operator instead.");
+                    throwInterfaceExtensionError(superclassString);
                 }
                 
                 setSuperclass(superclass);
@@ -688,7 +688,7 @@ public class TYClass {
                         TYClass superclass = module.getClass(superclassString);
                         if (superclass.isInterface()) {
                             
-                            Runner.setPostFinalizeError(Errors.Classes.INHERITANCE_ERROR, "Cannot extend interface " + superclassString + ".  Use the >> implementation operator instead.");
+                            throwInterfaceExtensionError(superclassString);
                         }
                         
                         setSuperclass(superclass);
@@ -705,7 +705,7 @@ public class TYClass {
                         TYClass superclass = ClassRegistry.getClass(superclassString);
                         if (superclass.isInterface()) {
                             
-                            Runner.setPostFinalizeError(Errors.Classes.INHERITANCE_ERROR, "Cannot extend interface " + superclassString + ".  Use the >> implementation operator instead.");
+                            throwInterfaceExtensionError(superclassString);
                         }
                         
                         setSuperclass(superclass);
@@ -715,7 +715,7 @@ public class TYClass {
                         TYClass superclass = trinity.getClass(superclassString);
                         if (superclass.isInterface()) {
                             
-                            Runner.setPostFinalizeError(Errors.Classes.INHERITANCE_ERROR, "Cannot extend interface " + superclassString + ".  Use the >> implementation operator instead.");
+                            throwInterfaceExtensionError(superclassString);
                         }
                         
                         setSuperclass(superclass);
@@ -739,7 +739,7 @@ public class TYClass {
                     TYClass superinterface = module.getClass(superinterfaceString);
                     if (!superinterface.isInterface()) {
                         
-                        Runner.setPostFinalizeError(Errors.Classes.INHERITANCE_ERROR, "Cannot implement class " + superinterfaceString + ".  Use the << extension operator instead.");
+                        throwClassImplementationError(superinterfaceString);
                     }
                     
                     superinterfaceList.add(superinterface);
@@ -759,7 +759,7 @@ public class TYClass {
                             TYClass superinterface = module.getClass(superinterfaceString);
                             if (!superinterface.isInterface()) {
                                 
-                                Runner.setPostFinalizeError(Errors.Classes.INHERITANCE_ERROR, "Cannot implement class " + superinterfaceString + ".  Use the << extension operator instead.");
+                                throwClassImplementationError(superinterfaceString);
                             }
                             
                             superinterfaceList.add(superinterface);
@@ -776,7 +776,7 @@ public class TYClass {
                             TYClass superinterface = ClassRegistry.getClass(superinterfaceString);
                             if (!superinterface.isInterface()) {
                                 
-                                Runner.setPostFinalizeError(Errors.Classes.INHERITANCE_ERROR, "Cannot implement class " + superinterfaceString + ".  Use the << extension operator instead.");
+                                throwClassImplementationError(superinterfaceString);
                             }
                             
                             superinterfaceList.add(superinterface);
@@ -786,7 +786,7 @@ public class TYClass {
                             TYClass superinterface = trinity.getClass(superinterfaceString);
                             if (!superinterface.isInterface()) {
                                 
-                                Runner.setPostFinalizeError(Errors.Classes.INHERITANCE_ERROR, "Cannot implement class " + superinterfaceString + ".  Use the << extension operator instead.");
+                                throwClassImplementationError(superinterfaceString);
                             }
                             
                             superinterfaceList.add(superinterface);
@@ -817,6 +817,16 @@ public class TYClass {
         Set<String> callables = compileCallableMethods();
         callableMethods = new ArrayList<>(callables);
         Collections.sort(callableMethods);
+    }
+    
+    private void throwInterfaceExtensionError(String string) {
+        
+        Runner.setPostFinalizeError(Errors.Classes.INHERITANCE_ERROR, "Cannot extend interface " + string + ".  Use the >> implementation operator instead.");
+    }
+    
+    private void throwClassImplementationError(String string) {
+        
+        Runner.setPostFinalizeError(Errors.Classes.INHERITANCE_ERROR, "Cannot implement class " + string + ".  Use the << extension operator instead.");
     }
     
     private void checkSuperinterfaceMethods(TYClass superinterface) {

--- a/src/main/java/com/github/chrisblutz/trinity/lang/threading/TYThread.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/threading/TYThread.java
@@ -3,10 +3,10 @@ package com.github.chrisblutz.trinity.lang.threading;
 import com.github.chrisblutz.trinity.Trinity;
 import com.github.chrisblutz.trinity.interpreter.errors.TrinityErrorException;
 import com.github.chrisblutz.trinity.lang.TYObject;
+import com.github.chrisblutz.trinity.lang.TYRuntime;
 import com.github.chrisblutz.trinity.lang.errors.Errors;
 import com.github.chrisblutz.trinity.lang.errors.stacktrace.TrinityStack;
 import com.github.chrisblutz.trinity.lang.procedures.TYProcedure;
-import com.github.chrisblutz.trinity.lang.TYRuntime;
 import com.github.chrisblutz.trinity.lang.types.procedures.TYProcedureObject;
 import com.github.chrisblutz.trinity.runner.Runner;
 
@@ -27,6 +27,8 @@ public class TYThread {
     private TrinityStack trinityStack;
     
     private TYProcedureObject errorHandler = null;
+    
+    public static final TYThread DEFAULT_DUMP_THREAD = new TYThread("main", new TYProcedure((runtime, thisObj, params) -> TYObject.NONE, false), new TYRuntime());
     
     public TYThread(String name, TYProcedure procedure, TYRuntime runtime) {
         
@@ -120,7 +122,7 @@ public class TYThread {
     
     public static TYThread getThread(Thread thread) {
         
-        return threads.get(thread);
+        return threads.getOrDefault(thread, DEFAULT_DUMP_THREAD);
     }
     
     public static TYThread getCurrentThread() {

--- a/src/main/java/com/github/chrisblutz/trinity/lang/types/nativeutils/NativeClass.java
+++ b/src/main/java/com/github/chrisblutz/trinity/lang/types/nativeutils/NativeClass.java
@@ -78,9 +78,15 @@ class NativeClass {
         });
         TrinityNatives.registerMethod(TrinityNatives.Classes.CLASS, "getMethods", (runtime, thisObj, params) -> {
             
+            TYClass tyClass = TrinityNatives.cast(TYClassObject.class, thisObj).getInternalClass();
             List<TYObject> methods = new ArrayList<>();
             
-            for (TYMethod m : TrinityNatives.cast(TYClassObject.class, thisObj).getInternalClass().getMethodArray()) {
+            for (TYMethod m : tyClass.getMethodArray()) {
+                
+                if (tyClass.isInterface() && m.getName().equals("initialize")) {
+                    
+                    continue;
+                }
                 
                 methods.add(NativeStorage.getMethodObject(m));
             }

--- a/src/main/java/com/github/chrisblutz/trinity/parser/tokens/Token.java
+++ b/src/main/java/com/github/chrisblutz/trinity/parser/tokens/Token.java
@@ -14,7 +14,7 @@ public enum Token {
     
     // Definitions
     IMPORT("import"), MODULE("module"), CLASS("class"), DEF("def"), NATIVE("native"),
-    CLASS_EXTENSION("<<"), GLOBAL_VAR("$"), VAL("val"), VAR("var"), INIT("init"),
+    CLASS_EXTENSION("<<"), GLOBAL_VAR("$"), VAL("val"), VAR("var"), INIT("init"), INTERFACE("interface"), INTERFACE_IMPLEMENTATION(">>"),
     
     // Modifiers
     STATIC("static"), SECURE("secure"), SCOPE_MODIFIER("\0"), PUBLIC_SCOPE("public"), PROTECTED_SCOPE("protected"), MODULE_PROTECTED_SCOPE("module-protected"), PRIVATE_SCOPE("private"),
@@ -26,7 +26,7 @@ public enum Token {
     AND("&&"), OR("||"),
     
     // Bitwise Operators
-    BITWISE_XOR("^"), BITWISE_COMPLEMENT("~"), BIT_SHIFT_RIGHT(">>"), BIT_SHIFT_LOGICAL_RIGHT(">>>"),
+    BITWISE_XOR("^"), BITWISE_COMPLEMENT("~"), BIT_SHIFT_LOGICAL_RIGHT(">>>"),
     BITWISE_AND_EQUAL("&="), BITWISE_OR_EQUAL("|="), BITWISE_XOR_EQUAL("^="), BIT_SHIFT_LEFT_EQUAL("<<="), BIT_SHIFT_RIGHT_EQUAL(">>="), BIT_SHIFT_LOGICAL_RIGHT_EQUAL(">>>="),
     
     // Native Checks


### PR DESCRIPTION
This PR adds support for interfaces, which act like class templates.  No instances of interfaces can be created, and they may not contain `initialize` method definitions.  Interfaces support static and instance methods.  Interfaces can extend other interfaces, and classes can implement multiple interfaces.  Implementation of interfaces is provided by the `X >> Y` syntax (contrary to `X << Y` class extension).

This PR also refines class/interface extension/implementation syntax and adds support for `X << Y.Z`.  Previously only `X << Z` was allowed, and would need to be preceded by `import Y`.